### PR TITLE
Added Missing Dot Before Class Name.

### DIFF
--- a/Snippets/Gutter line numbers.md
+++ b/Snippets/Gutter line numbers.md
@@ -40,7 +40,7 @@
 }
 
 /* align vertically with header */
-cm-s-obsidian .HyperMD-header {
+.cm-s-obsidian .HyperMD-header {
   padding-top:0.125em;
   padding-bottom:0.125em;
 } 


### PR DESCRIPTION
Noticed a small styling issue – added a missing dot before the class name.